### PR TITLE
updates to ByteArray implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/mvahowe/proskomma-go
+
+go 1.15

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"./succinct"
+	"github.com/mvahowe/proskomma-go/succinct"
 )
 
 func main() {

--- a/succinct/byte_array_test.go
+++ b/succinct/byte_array_test.go
@@ -6,11 +6,8 @@ import (
 
 func TestConstructor(t *testing.T) {
 	ba := NewByteArray(32)
-	if ba.usedBytes != 0 {
-		t.Errorf("usedBytes for new ByteArray is %d not 0", ba.usedBytes)
-	}
-	if len(ba.bytes) != 32 {
-		t.Errorf("bytes length for new ByteArray is %d not 32", len(ba.bytes))
+	if cap(ba.bytes) != 32 {
+		t.Errorf("bytes capacity for new ByteArray is %d not 32", len(ba.bytes))
 	}
 }
 
@@ -22,10 +19,7 @@ func TestReadPushByte(t *testing.T) {
 	if err == nil {
 		t.Errorf("Accessing unset byte for ByteArray did not throw error")
 	}
-	err = ba.PushByte(99)
-	if err != nil {
-		t.Errorf("PushByte for ByteArray threw error: '%s'", err)
-	}
+	ba.PushByte(99)
 	v, err = ba.Byte(0)
 	if err != nil {
 		t.Errorf("Accessing set byte for ByteArray threw error: %s", err)
@@ -38,7 +32,7 @@ func TestReadPushByte(t *testing.T) {
 func TestWriteByte(t *testing.T) {
 	ba := NewByteArray(1)
 	var v uint8
-	_ = ba.PushByte(93)
+	ba.PushByte(93)
 	v, _ = ba.Byte(0)
 	if v != 93 {
 		t.Errorf("0th byte for ByteArray should be 93 after PushByte")
@@ -59,10 +53,7 @@ func TestWriteByte(t *testing.T) {
 
 func TestPushReadBytes(t *testing.T) {
 	ba := NewByteArray(10)
-	err := ba.PushBytes([]uint8{2, 4, 6, 8})
-	if err != nil {
-		t.Errorf("PushBytes for ByteArray threw error: %s", err)
-	}
+	ba.PushBytes([]uint8{2, 4, 6, 8})
 	v, _ := ba.Byte(0)
 	if v != 2 {
 		t.Errorf("0th byte after PushBytes should be 2, not %d", v)
@@ -82,7 +73,7 @@ func TestPushReadBytes(t *testing.T) {
 
 func TestSetBytes(t *testing.T) {
 	ba := NewByteArray(10)
-	_ = ba.PushBytes([]uint8{2, 4, 6, 8})
+	ba.PushBytes([]uint8{2, 4, 6, 8})
 	v, _ := ba.Byte(2)
 	if v != 6 {
 		t.Errorf("2nd byte after PushBytes should be 6, not %d", v)
@@ -97,30 +88,9 @@ func TestSetBytes(t *testing.T) {
 	}
 }
 
-func TestGrow(t *testing.T) {
-	ba := NewByteArray(5)
-	_ = ba.PushBytes([]uint8{2, 4, 6, 8, 10})
-	if ba.usedBytes != 5 {
-		t.Errorf("usedBytes after initial push should be 5, not %d", ba.usedBytes)
-	}
-	if len(ba.bytes) != 5 {
-		t.Errorf("Length after initial push should be 5, not %d", len(ba.bytes))
-	}
-	_ = ba.PushByte(12)
-	if ba.usedBytes != 6 {
-		t.Errorf("usedBytes after 2nd push should be 6, not %d", ba.usedBytes)
-	}
-	if len(ba.bytes) != 10 {
-		t.Errorf("Length after 2nd push should be 10, not %d", len(ba.bytes))
-	}
-}
-
 func TestNByte(t *testing.T) {
 	ba := NewByteArray(5)
-	err := ba.PushNByte(127)
-	if err != nil {
-		t.Errorf("PushNByte threw error: %s", err)
-	}
+	ba.PushNByte(127)
 	v, err := ba.Byte(0)
 	if err != nil {
 		t.Errorf("Byte for ByteArray after 1st PushNByte threw error: %s", err)
@@ -135,10 +105,7 @@ func TestNByte(t *testing.T) {
 	if bv != 127 {
 		t.Errorf("First NByte should be 127, not %d", bv)
 	}
-	err = ba.PushNByte(130)
-	if err != nil {
-		t.Errorf("Byte for ByteArray after 2nd PushNByte threw error: %s", err)
-	}
+	ba.PushNByte(130)
 	v, err = ba.Byte(1)
 	if err != nil {
 		t.Errorf("Byte for ByteArray after 2nd PushNByte threw error: %s", err)
@@ -164,10 +131,7 @@ func TestNByte(t *testing.T) {
 
 func testCountedString(t *testing.T, testString string) {
 	ba := NewByteArray(32)
-	err:= ba.PushCountedString(testString)
-	if err != nil {
-		t.Errorf("1st PushCountedString threw error: %s", err)
-	}
+	ba.PushCountedString(testString)
 	v, err := ba.Byte(0)
 	if err != nil {
 		t.Errorf("Byte after 1st PushCountedString threw error: %s", err)
@@ -177,7 +141,7 @@ func testCountedString(t *testing.T, testString string) {
 			"String length after 1st PushCountedString should be %d, not %d",
 			len(testString),
 			v,
-			)
+		)
 	}
 	s, err := ba.CountedString(0)
 	if err != nil {
@@ -188,7 +152,7 @@ func testCountedString(t *testing.T, testString string) {
 			"expected first string to be '%s', not '%s'",
 			testString,
 			s,
-			)
+		)
 	}
 }
 
@@ -200,12 +164,12 @@ func TestCountedString(t *testing.T) {
 
 func TestClear(t *testing.T) {
 	ba := NewByteArray(32)
-	_ = ba.PushCountedString("abcde")
+	ba.PushCountedString("abcde")
 	ba.Clear()
-	if ba.usedBytes != 0 {
+	if len(ba.bytes) != 0 {
 		t.Errorf(
 			"usedBytes after Clear should be 0, not %d",
-			ba.usedBytes,
+			len(ba.bytes),
 		)
 	}
 }
@@ -217,11 +181,11 @@ func testNByteLength(t *testing.T, ba *ByteArray, v int, l int) {
 			v,
 			l,
 			ba.NByteLength(v),
-			)
+		)
 	}
 }
 
-func pow2 (y int) int {
+func pow2(y int) int {
 	ret := 1
 	for y > 0 {
 		ret *= 2
@@ -232,7 +196,7 @@ func pow2 (y int) int {
 
 func TestNByteLength(t *testing.T) {
 	ba := NewByteArray(32)
-	testNByteLength(t, &ba, pow2(7) - 1, 1)
+	testNByteLength(t, &ba, pow2(7)-1, 1)
 	testNByteLength(t, &ba, pow2(7), 2)
 	testNByteLength(t, &ba, pow2(14), 3)
 	testNByteLength(t, &ba, pow2(21), 4)
@@ -240,7 +204,7 @@ func TestNByteLength(t *testing.T) {
 
 func TestTrim(t *testing.T) {
 	ba := NewByteArray(32)
-	_ = ba.PushCountedString("abcdef")
+	ba.PushCountedString("abcdef")
 	err := ba.Trim()
 	if err != nil {
 		t.Errorf("Trim threw error: %s", err)
@@ -249,21 +213,23 @@ func TestTrim(t *testing.T) {
 		t.Errorf(
 			"bytes length after Trim should be 7, not %d",
 			len(ba.bytes),
-			)
+		)
 	}
 }
 
 func TestBase64(t *testing.T) {
 	ba := NewByteArray(32)
-	_ = ba.PushCountedString("abcde")
-	ba2 := NewByteArray(32)
-	ba2.fromBase64(ba.base64())
+	ba.PushCountedString("abcde")
+	ba2, err := NewByteArrayFromBase64(ba.base64())
+	if err != nil {
+		t.Errorf("NewByteArrayFromBase64 threw error: %s", err)
+	}
 	s, _ := ba2.CountedString(0)
 	if s != "abcde" {
 		t.Errorf(
 			"Base64'd string should be '%s', not '%s'",
 			"abcde",
 			s,
-			)
+		)
 	}
 }

--- a/succinct/items_test.go
+++ b/succinct/items_test.go
@@ -7,9 +7,12 @@ import (
 func TestHeaderBytes(t *testing.T) {
 	succinctString := "AwCvAwKAAwCJAwKABABqgQMCgAMA9QMBgQMCgAMAgQMCgAMAqQMCgAQAdYEDAoADAMUDAoAEAAOCAwKABAAGggMBgQMCgAMAgQMCgAQACIIDAYIDAoDDBYjDBoiDBomDBYkDALoDAoADAIcDAoADAIMDAoADAIUDAYEDAoADAYMEAAmCAwGBAwKAAwDeAwKABABBgwMCgAMAmgMCgAMA"
 	ba := NewByteArray(256)
-	ba.fromBase64(succinctString)
+	ba, err := NewByteArrayFromBase64(succinctString)
+	if err != nil {
+		t.Errorf("NewByteArrayFromBase64 threw error: %s", err)
+	}
 	pos := 0
-	for pos < ba.usedBytes {
+	for pos < len(ba.bytes) {
 		itemLength, itemType, itemSubtype, err := ba.headerBytes(pos)
 		if err != nil {
 			t.Errorf("headerBytes threw error: %s", err)
@@ -24,7 +27,7 @@ func TestHeaderBytes(t *testing.T) {
 		}
 		pos += itemLength
 	}
-	if pos != ba.usedBytes + 1 {
+	if pos != len(ba.bytes)+1 {
 		t.Errorf("last itemLength should point one past usedBytes")
 	}
 }

--- a/succinct/structure.go
+++ b/succinct/structure.go
@@ -16,8 +16,10 @@ func (e *EnumArrayMap) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	for enumLabel, enumB64 := range enumStrings {
-		ba := NewByteArray(256)
-		ba.fromBase64(enumB64)
+		ba, err := NewByteArrayFromBase64(enumB64)
+		if err != nil {
+			return err
+		}
 		_ = ba.Trim()
 		(*e)[enumLabel] = &ba
 	}
@@ -34,8 +36,10 @@ func (bam *BlockArrayMap) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	for blockFieldKey, blockFieldValue := range blocksStrings {
-		ba := NewByteArray(256)
-		ba.fromBase64(blockFieldValue)
+		ba, err := NewByteArrayFromBase64(blockFieldValue)
+		if err != nil {
+			return err
+		}
 		_ = ba.Trim()
 		(*bam)[blockFieldKey] = &ba
 	}


### PR DESCRIPTION
The bulk of this change is based on not needing to keep track of "usedBytes".  We can let the Go runtime do that since slices have a length and a capacity.  len(ba) will give the length of the slice used, cap(ba) will give the size allocated.  Also using `append()` in Push methods allows us to let the Go runtime manage "growing" the allocated size of the slice. append also works with nil slices allowing us to simplify the `Clear` method. 

Let me know if this removes some functionality that is needed that I didn't understand.  Also, I'm not sure `Trim` is all that useful if we are letting the runtime manage the slice but I left it in since I wasn't sure.
