### PR TITLE
use structs for Enums and Block types instead of maps

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,10 +13,8 @@ func main() {
 
 	for docId := range ds.Docs {
 		seq := ds.Docs[docId].Sequences[ds.Docs[docId].MainId]
-		for _, blockMap := range seq.BlockArrayMaps {
-			for k, v := range blockMap {
-				fmt.Println(k, v)
-			}
+		for _, block := range seq.Blocks {
+			fmt.Printf("%+v\n", block)
 		}
 	}
 }

--- a/succinct/byte_array.go
+++ b/succinct/byte_array.go
@@ -2,6 +2,7 @@ package succinct
 
 import (
 	b64 "encoding/base64"
+	"encoding/json"
 	"fmt"
 )
 
@@ -157,4 +158,24 @@ func (ba *ByteArray) NByteLength(v int) int {
 
 func (ba *ByteArray) base64() string {
 	return b64.StdEncoding.EncodeToString(ba.bytes)
+}
+
+func (ba *ByteArray) UnmarshalJSON(b []byte) error {
+	var base64Str string
+	err := json.Unmarshal(b, &base64Str)
+	if err != nil {
+		return err
+	}
+	*ba, err = NewByteArrayFromBase64(base64Str)
+	if err != nil {
+		return err
+	}
+	err = ba.Trim()
+	return err
+}
+
+func (ba *ByteArray) MarshalJSON() ([]byte, error) {
+	var dst []byte
+	b64.StdEncoding.Encode(dst, ba.bytes)
+	return dst, nil
 }

--- a/succinct/structure.go
+++ b/succinct/structure.go
@@ -6,49 +6,25 @@ import (
 	"os"
 )
 
-type EnumArrayMap map[string]*ByteArray
-
-func (e *EnumArrayMap) UnmarshalJSON(b []byte) error {
-	*e = make(EnumArrayMap)
-	var enumStrings map[string]string
-	err := json.Unmarshal(b, &enumStrings)
-	if err != nil {
-		return err
-	}
-	for enumLabel, enumB64 := range enumStrings {
-		ba, err := NewByteArrayFromBase64(enumB64)
-		if err != nil {
-			return err
-		}
-		_ = ba.Trim()
-		(*e)[enumLabel] = &ba
-	}
-	return nil
+type Enums struct {
+	IDs         ByteArray `json:"ids"`
+	WordLike    ByteArray `json:"wordLike"`
+	NotWordLike ByteArray `json:"notWordLike"`
+	ScopeBits   ByteArray `json:"scopeBits"`
+	GraftTypes  ByteArray `json:"graftTypes"`
 }
 
-type BlockArrayMap map[string]*ByteArray
-
-func (bam *BlockArrayMap) UnmarshalJSON(b []byte) error {
-	*bam = make(BlockArrayMap)
-	var blocksStrings map[string]string
-	err := json.Unmarshal(b, &blocksStrings)
-	if err != nil {
-		return err
-	}
-	for blockFieldKey, blockFieldValue := range blocksStrings {
-		ba, err := NewByteArrayFromBase64(blockFieldValue)
-		if err != nil {
-			return err
-		}
-		_ = ba.Trim()
-		(*bam)[blockFieldKey] = &ba
-	}
-	return nil
+type Block struct {
+	BlockScope     ByteArray `json:"bs"`
+	BlockGrafts    ByteArray `json:"bg"`
+	BlockItems     ByteArray `json:"c"`
+	OpenScopes     ByteArray `json:"os"`
+	IncludedScopes ByteArray `json:"is"`
 }
 
 type Sequence struct {
-	Type           string          `json:"type"`
-	BlockArrayMaps []BlockArrayMap `json:"blocks"`
+	Type   string  `json:"type"`
+	Blocks []Block `json:"blocks"`
 }
 
 type Doc struct {
@@ -58,9 +34,9 @@ type Doc struct {
 }
 
 type DocSet struct {
-	Id           string         `json:"id"`
-	EnumArrayMap EnumArrayMap   `json:"enums"`
-	Docs         map[string]Doc `json:"docs"`
+	Id    string         `json:"id"`
+	Enums Enums          `json:"enums"`
+	Docs  map[string]Doc `json:"docs"`
 }
 
 func DocSetFromJSON(pathString string) (*DocSet, error) {


### PR DESCRIPTION
* the structure seems to be well defined so we don't need
  the flexibility of a map
* cleaned up unmarshaling by moving it to the ByteArray type