### PR TITLE
Unpack Tokens, Scopes and Grafts

### DIFF
--- a/succinct/items.go
+++ b/succinct/items.go
@@ -16,8 +16,6 @@ func (ba *ByteArray) headerBytes(pos int) (int, int, int, error) {
 
 /*
 succinctScopeLabel
-succinctGraftName
-succinctGraftSeqId
  */
 
 func tokenChars(enums *Enums, succinct *ByteArray, itemSubType int, pos int) (string, error) {
@@ -33,4 +31,16 @@ func tokenChars(enums *Enums, succinct *ByteArray, itemSubType int, pos int) (st
 		return "", err
 	}
 	return enumForToken[itemIndex], nil
+}
+
+func graftName(enums *Enums, itemSubType int) (string, error) {
+	return enums.GraftTypes[itemSubType], nil
+}
+
+func graftSeqId(enums *Enums, succinct *ByteArray, pos int) (string, error) {
+	itemIndex, err := succinct.NByte(pos + 2)
+	if err != nil {
+		return "", err
+	}
+	return enums.IDs[itemIndex], nil
 }

--- a/succinct/items.go
+++ b/succinct/items.go
@@ -13,3 +13,24 @@ func (ba *ByteArray) headerBytes(pos int) (int, int, int, error) {
 	}
 	return int(itemLength), int(itemType), int(itemSubtype), nil
 }
+
+/*
+succinctScopeLabel
+succinctGraftName
+succinctGraftSeqId
+ */
+
+func tokenChars(enums *Enums, succinct *ByteArray, itemSubType int, pos int) (string, error) {
+	enumCategory := tokenCategory[itemSubType]
+	var enumForToken EnumList
+	if enumCategory == "wordLike" {
+		enumForToken = enums.WordLike
+	} else {
+		enumForToken = enums.NotWordLike
+	}
+	itemIndex, err := succinct.NByte(pos + 2)
+	if err != nil {
+		return "", err
+	}
+	return enumForToken[itemIndex], nil
+}

--- a/succinct/items.go
+++ b/succinct/items.go
@@ -1,5 +1,7 @@
 package succinct
 
+import "strings"
+
 func (ba *ByteArray) headerBytes(pos int) (int, int, int, error) {
 	headerByte, err := ba.Byte(pos)
 	if err != nil {
@@ -13,10 +15,6 @@ func (ba *ByteArray) headerBytes(pos int) (int, int, int, error) {
 	}
 	return int(itemLength), int(itemType), int(itemSubtype), nil
 }
-
-/*
-succinctScopeLabel
- */
 
 func tokenChars(enums *Enums, succinct *ByteArray, itemSubType int, pos int) (string, error) {
 	enumCategory := tokenCategory[itemSubType]
@@ -43,4 +41,21 @@ func graftSeqId(enums *Enums, succinct *ByteArray, pos int) (string, error) {
 		return "", err
 	}
 	return enums.IDs[itemIndex], nil
+}
+
+func scopeLabel(enums *Enums, succinct *ByteArray, itemSubType int, pos int) (string, error) {
+	nScopeBits := nComponentsForScope[itemSubType]
+	offset := 2
+	scopeBits := []string{scopeStrings[itemSubType]}
+	for nScopeBits > 1 {
+		scopeBitIndex, err := succinct.NByte(pos + 2)
+		if err != nil {
+			return "", err
+		}
+		scopeBit := enums.ScopeBits[scopeBitIndex]
+		scopeBits = append(scopeBits, scopeBit)
+		offset += succinct.NByteLength(int(scopeBitIndex))
+		nScopeBits--
+	}
+	return strings.Join(scopeBits, "/"), nil
 }

--- a/succinct/items_test.go
+++ b/succinct/items_test.go
@@ -4,13 +4,7 @@ import (
 	"testing"
 )
 
-func TestHeaderBytes(t *testing.T) {
-	succinctString := "AwCvAwKAAwCJAwKABABqgQMCgAMA9QMBgQMCgAMAgQMCgAMAqQMCgAQAdYEDAoADAMUDAoAEAAOCAwKABAAGggMBgQMCgAMAgQMCgAQACIIDAYIDAoDDBYjDBoiDBomDBYkDALoDAoADAIcDAoADAIMDAoADAIUDAYEDAoADAYMEAAmCAwGBAwKAAwDeAwKABABBgwMCgAMAmgMCgAMA"
-	ba := NewByteArray(256)
-	ba, err := NewByteArrayFromBase64(succinctString)
-	if err != nil {
-		t.Errorf("NewByteArrayFromBase64 threw error: %s", err)
-	}
+func checkHeaderBytes(t *testing.T, ba *ByteArray) {
 	pos := 0
 	for pos < len(ba.bytes) {
 		itemLength, itemType, itemSubtype, err := ba.headerBytes(pos)
@@ -27,7 +21,13 @@ func TestHeaderBytes(t *testing.T) {
 		}
 		pos += itemLength
 	}
-	if pos != len(ba.bytes)+1 {
-		t.Errorf("last itemLength should point one past usedBytes")
+	if pos != len(ba.bytes) {
+		t.Errorf("last itemLength should point one past byteArray (%d/%d)", pos, len(ba.bytes))
 	}
+}
+
+func TestHeaderBytes(t *testing.T) {
+	succinctString := "AwCvAwKAAwCJAwKABABqgQMCgAMA9QMBgQMCgAMAgQMCgAMAqQMCgAQAdYEDAoADAMUDAoAEAAOCAwKABAAGggMBgQMCgAMAgQMCgAQACIIDAYIDAoDDBYjDBoiDBomDBYkDALoDAoADAIcDAoADAIMDAoADAIUDAYEDAoADAYMEAAmCAwGBAwKAAwDeAwKABABBgwMCgAMAmgMCgAMA+QMCgAMAlQMCgAMAhAMCgAMAgwMCgAMAiwMCgAMAtQMBggMBhMMFicMGiQ=="
+	ba, _ := NewByteArrayFromBase64(succinctString)
+	checkHeaderBytes(t, &ba)
 }

--- a/succinct/lookups.go
+++ b/succinct/lookups.go
@@ -62,6 +62,27 @@ var scopeString2Int = map[string]int{
 
 var scopeStrings = reverseIntLookup(scopeString2Int)
 
+var nComponentsForScope = []int{
+	2, // "blockTag"
+	2, // "inline"
+	2, // "chapter"
+	2, // "pubChapter"
+	2, // "altChapter"
+	2, // "verses"
+	2, // "verse"
+	2, // "pubVerse"
+	2, // "altVerse"
+	2, // "esbCat"
+	2, // "span"
+	1, // "table"
+	4, // "cell"
+	2, // "milestone"
+	2, // "spanWithAtts"
+	6, // "attribute"
+	1, // "hangingGraft"
+	1, // "orphanTokens"
+}
+
 var tokenString2Int = map[string]int{
 	"wordLike":      0,
 	"punctuation":   1,

--- a/succinct/lookups.go
+++ b/succinct/lookups.go
@@ -75,13 +75,13 @@ var tokenString2Int = map[string]int{
 
 var tokenStrings = reverseIntLookup(tokenString2Int)
 
-var tokenCategory = map[string]string{
-	"wordLike":      "wordLike",
-	"punctuation":   "notWordLike",
-	"lineSpace":     "notWordLike",
-	"eol":           "notWordLike",
-	"softLineBreak": "notWordLike",
-	"noBreakSpace":  "notWordLike",
-	"bareSlash":     "notWordLike",
-	"unknown":       "notWordLike",
+var tokenCategory = []string{
+	"wordLike",
+	"notWordLike",
+	"notWordLike",
+	"notWordLike",
+	"notWordLike",
+	"notWordLike",
+	"notWordLike",
+	"notWordLike",
 }

--- a/succinct/structure_test.go
+++ b/succinct/structure_test.go
@@ -1,19 +1,35 @@
 package succinct
 
 import (
-	"fmt"
 	"testing"
 )
 
-func TestLoadSuccinctJSON(t *testing.T) {
-	ds, err := DocSetFromJSON(
-		"../test_data/serialize_example.json",
-	)
+func loadSuccinctJSON(t *testing.T, path string) *DocSet {
+	ds, err := DocSetFromJSON(path)
 	if err != nil {
-		fmt.Printf("error getting DocSet from JSON: %s\n", err)
+		t.Errorf("error getting DocSet from JSON: %s\n", err)
 	}
 	if ds == nil {
-		fmt.Print("Returned docSet is nil")
+		t.Errorf("Returned docSet is nil")
+	}
+	return ds
+}
+
+func TestLoadSuccinctJSON(t *testing.T) {
+	loadSuccinctJSON(t, "../test_data/serialize_example.json")
+}
+
+func TestHeaderBytesFromJSON(t *testing.T) {
+	ds := loadSuccinctJSON(t, "../test_data/serialize_example.json")
+	for docId := range ds.Docs {
+		seq := ds.Docs[docId].Sequences[ds.Docs[docId].MainId]
+		for _, block := range seq.Blocks {
+			checkHeaderBytes(t, &block.BlockItems)
+			checkHeaderBytes(t, &block.BlockGrafts)
+			checkHeaderBytes(t, &block.BlockScope)
+			checkHeaderBytes(t, &block.IncludedScopes)
+			checkHeaderBytes(t, &block.OpenScopes)
+		}
 	}
 }
 

--- a/succinct/structure_test.go
+++ b/succinct/structure_test.go
@@ -33,3 +33,32 @@ func TestHeaderBytesFromJSON(t *testing.T) {
 	}
 }
 
+func TestTokenChars(t *testing.T) {
+	ds := loadSuccinctJSON(t, "../test_data/serialize_example.json")
+	for docId := range ds.Docs {
+		seq := ds.Docs[docId].Sequences[ds.Docs[docId].MainId]
+		for _, block := range seq.Blocks {
+			pos := 0
+			ba := block.BlockItems
+			for pos < len(ba.bytes) {
+				itemLength, itemType, itemSubtype, err := ba.headerBytes(pos)
+				if err != nil {
+					t.Errorf("headerBytes threw error: %s", err)
+				}
+				if itemType > len(itemStrings) {
+					t.Errorf("Unexpected itemType %d", itemType)
+				}
+				if itemType == 0 {
+					tokenString, err := tokenChars(&ds.Enums, &ba, itemSubtype, pos)
+					if err != nil {
+						t.Errorf("Error from tokenChars: %s", err)
+					}
+					if len(tokenString) == 0 {
+						t.Errorf("Empty string from tokenChars")
+					}
+				}
+				pos += itemLength
+			}
+		}
+	}
+}

--- a/succinct/structure_test.go
+++ b/succinct/structure_test.go
@@ -104,3 +104,33 @@ func TestGraftNameAndSeqIDFromItems(t *testing.T) {
 		t.Errorf("No grafts found")
 	}
 }
+
+func TestScopeLabel(t *testing.T) {
+	ds := loadSuccinctJSON(t, "../test_data/serialize_example.json")
+	for docId := range ds.Docs {
+		seq := ds.Docs[docId].Sequences[ds.Docs[docId].MainId]
+		for _, block := range seq.Blocks {
+			pos := 0
+			ba := block.BlockItems
+			for pos < len(ba.bytes) {
+				itemLength, itemType, itemSubtype, err := ba.headerBytes(pos)
+				if err != nil {
+					t.Errorf("headerBytes threw error: %s", err)
+				}
+				if itemType > len(itemStrings) {
+					t.Errorf("Unexpected itemType %d", itemType)
+				}
+				if itemType == 2 || itemType == 3 {
+					scopeLabel, err := scopeLabel(&ds.Enums, &ba, itemSubtype, pos)
+					if err != nil {
+						t.Errorf("Error from scopeLabel: %s", err)
+					}
+					if len(scopeLabel) == 0 {
+						t.Errorf("Empty string from graftName")
+					}
+				}
+				pos += itemLength
+			}
+		}
+	}
+}

--- a/succinct/structure_test.go
+++ b/succinct/structure_test.go
@@ -62,3 +62,45 @@ func TestTokenChars(t *testing.T) {
 		}
 	}
 }
+
+func TestGraftNameAndSeqIDFromItems(t *testing.T) {
+	ds := loadSuccinctJSON(t, "../test_data/serialize_example.json")
+	foundGraft := false
+	for docId := range ds.Docs {
+		seq := ds.Docs[docId].Sequences[ds.Docs[docId].MainId]
+		for _, block := range seq.Blocks {
+			pos := 0
+			ba := block.BlockItems
+			for pos < len(ba.bytes) {
+				itemLength, itemType, itemSubtype, err := ba.headerBytes(pos)
+				if err != nil {
+					t.Errorf("headerBytes threw error: %s", err)
+				}
+				if itemType > len(itemStrings) {
+					t.Errorf("Unexpected itemType %d", itemType)
+				}
+				if itemType == 1 {
+					foundGraft = true
+					graftName, err := graftName(&ds.Enums, itemSubtype)
+					if err != nil {
+						t.Errorf("Error from graftName: %s", err)
+					}
+					if len(graftName) == 0 {
+						t.Errorf("Empty string from graftName")
+					}
+					graftSeqId, err := graftSeqId(&ds.Enums, &ba, pos)
+					if err != nil {
+						t.Errorf("Error from graftSeqId: %s", err)
+					}
+					if len(graftSeqId) == 0 {
+						t.Errorf("Empty string from graftSeqId")
+					}
+				}
+				pos += itemLength
+			}
+		}
+	}
+	if !foundGraft {
+		t.Errorf("No grafts found")
+	}
+}

--- a/succinct/structure_test.go
+++ b/succinct/structure_test.go
@@ -1,0 +1,19 @@
+package succinct
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestLoadSuccinctJSON(t *testing.T) {
+	ds, err := DocSetFromJSON(
+		"../test_data/serialize_example.json",
+	)
+	if err != nil {
+		fmt.Printf("error getting DocSet from JSON: %s\n", err)
+	}
+	if ds == nil {
+		fmt.Print("Returned docSet is nil")
+	}
+}
+


### PR DESCRIPTION
This PR adds the next layer of logic to the byte-level operators implemented previously. (Print the strings found in the unit tests to see the actual data being extracted.

In many places the Go implementation is cleaner. One exception is items.go:22 which feels like a kludge - maybe a Go enum of Proskomma enums would be good here?

I'm returning scope labels as slash-separated strings, which is what JS uses internally. There might be a better struct to use in Go. (Testing == and startsWith() needs to be cheap.)

After this, there are some more architectural decisions to make about what a "complete" token, graft and scope will look like. (In JS they are objects.)