### PR TITLE
ported Insert function

### DIFF
--- a/succinct/byte_array.go
+++ b/succinct/byte_array.go
@@ -253,3 +253,20 @@ func (ba *ByteArray) DeleteItem(n int) error {
 	}
 	return nil
 }
+
+func (ba *ByteArray) Insert(n int, iba ByteArray) error {
+	if n < len(ba.bytes)+len(iba.bytes) {
+		displacedBytes := make([]uint8, len(ba.bytes)-n)
+		copy(displacedBytes, ba.bytes[n:])
+		ba.bytes = append(ba.bytes, iba.bytes...)
+		err := ba.SetBytes(n+len(iba.bytes), displacedBytes)
+		if err != nil {
+			return err
+		}
+	}
+	err := ba.SetBytes(n, iba.bytes)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/succinct/byte_array.go
+++ b/succinct/byte_array.go
@@ -254,19 +254,18 @@ func (ba *ByteArray) DeleteItem(n int) error {
 	return nil
 }
 
-func (ba *ByteArray) Insert(n int, iba ByteArray) error {
-	if n < len(ba.bytes)+len(iba.bytes) {
-		displacedBytes := make([]uint8, len(ba.bytes)-n)
-		copy(displacedBytes, ba.bytes[n:])
-		ba.bytes = append(ba.bytes, iba.bytes...)
-		err := ba.SetBytes(n+len(iba.bytes), displacedBytes)
-		if err != nil {
-			return err
-		}
+func (ba *ByteArray) Insert(n int, iba ByteArray) {
+	newLength := len(ba.bytes) + len(iba.bytes)
+	if newLength <= cap(ba.bytes) {
+		ba2 := ba.bytes[:newLength]
+		copy(ba2[n+len(iba.bytes):], ba.bytes[n:])
+		copy(ba2[n:], iba.bytes)
+		ba.bytes = ba2
+		return
 	}
-	err := ba.SetBytes(n, iba.bytes)
-	if err != nil {
-		return err
-	}
-	return nil
+	ba2 := make([]uint8, len(ba.bytes)+len(iba.bytes))
+	copy(ba2, ba.bytes[:n])
+	copy(ba2[n:], iba.bytes)
+	copy(ba2[n+len(iba.bytes):], ba.bytes[n:])
+	ba.bytes = ba2
 }

--- a/succinct/byte_array_test.go
+++ b/succinct/byte_array_test.go
@@ -402,10 +402,7 @@ func TestInsert(t *testing.T) {
 
 	iba := NewByteArray(8)
 	iba.pushSuccinctGraftBytes(10, 143)
-	err = ba.Insert(int(tokenLength), iba)
-	if err != nil {
-		t.Errorf("error: %s", err)
-	}
+	ba.Insert(int(tokenLength), iba)
 
 	firstLength, err := ba.Byte(0)
 	if err != nil {
@@ -443,10 +440,7 @@ func TestInsert(t *testing.T) {
 
 	iba2 := NewByteArray(1)
 	iba2.pushSuccinctGraftBytes(5, 47)
-	err = ba.Insert(int(firstLength+secondLength+thirdLength), iba2)
-	if err != nil {
-		t.Errorf("error: %s", err)
-	}
+	ba.Insert(int(firstLength+secondLength+thirdLength), iba2)
 
 	fourthLength, err := ba.Byte(int(firstLength + secondLength + thirdLength))
 	if err != nil {
@@ -460,5 +454,21 @@ func TestInsert(t *testing.T) {
 
 	if int(firstLength+secondLength+thirdLength+fourthLength) != len(ba.bytes) {
 		t.Errorf("sum of first/second/third/fourth lengths expected to be %d but was %d", len(ba.bytes), int(firstLength+secondLength+thirdLength+fourthLength))
+	}
+
+	ba2 := NewByteArray(32)
+	ba2.pushSuccinctTokenBytes(1, 299)
+	ba2.pushSuccinctScopeBytes(3, 2, []uint32{567})
+	tokenLength, err = ba.Byte(0)
+	if err != nil {
+		t.Errorf("error: %s", err)
+	}
+	tokenLength = tokenLength & 0x0000003F
+	iba3 := NewByteArray(8)
+	iba3.pushSuccinctGraftBytes(10, 143)
+	expectedLength := len(ba2.bytes) + len(iba3.bytes)
+	ba2.Insert(int(tokenLength), iba3)
+	if len(ba2.bytes) != expectedLength {
+		t.Errorf("length expected to be %d but was %d", expectedLength, len(ba2.bytes))
 	}
 }

--- a/succinct/byte_array_test.go
+++ b/succinct/byte_array_test.go
@@ -379,5 +379,80 @@ func TestDeleteItem(t *testing.T) {
 	}
 }
 
-//func TestInsert(t *testing.T) {
-//}
+func TestInsert(t *testing.T) {
+	ba := NewByteArray(8)
+	ba.pushSuccinctTokenBytes(1, 299)
+	ba.pushSuccinctScopeBytes(3, 2, []uint32{567})
+
+	tokenLength, err := ba.Byte(0)
+	if err != nil {
+		t.Errorf("error: %s", err)
+	}
+	tokenLength = tokenLength & 0x0000003F
+
+	scopeLength, err := ba.Byte(int(tokenLength))
+	if err != nil {
+		t.Errorf("error: %s", err)
+	}
+	scopeLength = scopeLength & 0x0000003F
+
+	if int(tokenLength+scopeLength) != len(ba.bytes) {
+		t.Errorf("sum of tokenLength and scopeLength expected to be %d but was %d", len(ba.bytes), int(tokenLength+scopeLength))
+	}
+
+	iba := NewByteArray(8)
+	iba.pushSuccinctGraftBytes(10, 143)
+	ba.Insert(int(tokenLength), iba)
+
+	firstLength, err := ba.Byte(0)
+	if err != nil {
+		t.Errorf("error: %s", err)
+	}
+	firstLength = firstLength & 0x0000003F
+
+	secondLength, err := ba.Byte(int(firstLength))
+	if err != nil {
+		t.Errorf("error: %s", err)
+	}
+	secondLength = secondLength & 0x0000003F
+
+	thirdLength, err := ba.Byte(int(firstLength + secondLength))
+	if err != nil {
+		t.Errorf("error: %s", err)
+	}
+	thirdLength = thirdLength & 0x0000003F
+
+	if firstLength != tokenLength {
+		t.Errorf("firstLength expected to be %d but was %d", tokenLength, firstLength)
+	}
+
+	if int(secondLength) != len(iba.bytes) {
+		t.Errorf("secondLength expected to be %d but was %d", len(iba.bytes), int(secondLength))
+	}
+
+	if thirdLength != scopeLength {
+		t.Errorf("thirdLength expected to be %d but was %d", scopeLength, thirdLength)
+	}
+
+	if int(firstLength+secondLength+thirdLength) != len(ba.bytes) {
+		t.Errorf("sum of first/second/third lengths expected to be %d but was %d", len(ba.bytes), int(firstLength+secondLength+thirdLength))
+	}
+
+	iba2 := NewByteArray(1)
+	iba2.pushSuccinctGraftBytes(5, 47)
+	ba.Insert(int(firstLength+secondLength+thirdLength), iba2)
+
+	fourthLength, err := ba.Byte(int(firstLength + secondLength + thirdLength))
+	if err != nil {
+		t.Errorf("error: %s", err)
+	}
+	fourthLength = fourthLength & 0x0000003F
+
+	if int(fourthLength) != len(iba2.bytes) {
+		t.Errorf("fourthLength expected to be %d but was %d", int(fourthLength), len(iba2.bytes))
+	}
+
+	if int(firstLength+secondLength+thirdLength+fourthLength) != len(ba.bytes) {
+		t.Errorf("sum of first/second/third/fourth lengths expected to be %d but was %d", len(ba.bytes), int(firstLength+secondLength+thirdLength+fourthLength))
+	}
+}

--- a/succinct/byte_array_test.go
+++ b/succinct/byte_array_test.go
@@ -380,7 +380,7 @@ func TestDeleteItem(t *testing.T) {
 }
 
 func TestInsert(t *testing.T) {
-	ba := NewByteArray(8)
+	ba := NewByteArray(12)
 	ba.pushSuccinctTokenBytes(1, 299)
 	ba.pushSuccinctScopeBytes(3, 2, []uint32{567})
 
@@ -454,21 +454,5 @@ func TestInsert(t *testing.T) {
 
 	if int(firstLength+secondLength+thirdLength+fourthLength) != len(ba.bytes) {
 		t.Errorf("sum of first/second/third/fourth lengths expected to be %d but was %d", len(ba.bytes), int(firstLength+secondLength+thirdLength+fourthLength))
-	}
-
-	ba2 := NewByteArray(32)
-	ba2.pushSuccinctTokenBytes(1, 299)
-	ba2.pushSuccinctScopeBytes(3, 2, []uint32{567})
-	tokenLength, err = ba.Byte(0)
-	if err != nil {
-		t.Errorf("error: %s", err)
-	}
-	tokenLength = tokenLength & 0x0000003F
-	iba3 := NewByteArray(8)
-	iba3.pushSuccinctGraftBytes(10, 143)
-	expectedLength := len(ba2.bytes) + len(iba3.bytes)
-	ba2.Insert(int(tokenLength), iba3)
-	if len(ba2.bytes) != expectedLength {
-		t.Errorf("length expected to be %d but was %d", expectedLength, len(ba2.bytes))
 	}
 }

--- a/succinct/byte_array_test.go
+++ b/succinct/byte_array_test.go
@@ -324,23 +324,9 @@ func TestBase64(t *testing.T) {
 
 func TestDeleteItem(t *testing.T) {
 	ba := NewByteArray(1)
-	lengthPos := len(ba.bytes)
-	ba.PushByte(0)
-	ba.PushByte(1)
-	ba.PushNByte(299)
-	ba.SetByte(lengthPos, uint8((len(ba.bytes)-lengthPos)|itemString2Int["token"]<<6))
-
-	lengthPos = len(ba.bytes)
-	ba.PushByte(0)
-	ba.PushByte(10)
-	ba.PushNByte(143)
-	ba.SetByte(lengthPos, uint8((len(ba.bytes)-lengthPos)|itemString2Int["graft"]<<6))
-
-	lengthPos = len(ba.bytes)
-	ba.PushByte(0)
-	ba.PushByte(2)
-	ba.PushNByte(567)
-	ba.SetByte(lengthPos, uint8((len(ba.bytes)-lengthPos)|3<<6))
+	ba.pushSuccinctTokenBytes(1, 299)
+	ba.pushSuccinctGraftBytes(10, 143)
+	ba.pushSuccinctScopeBytes(3, 2, []uint32{567})
 
 	firstLength, err := ba.Byte(0)
 	if err != nil {
@@ -392,3 +378,6 @@ func TestDeleteItem(t *testing.T) {
 		t.Errorf("newFullLength expected to be %d but was %d", len(ba.bytes), newFullLength)
 	}
 }
+
+//func TestInsert(t *testing.T) {
+//}

--- a/succinct/byte_array_test.go
+++ b/succinct/byte_array_test.go
@@ -402,7 +402,10 @@ func TestInsert(t *testing.T) {
 
 	iba := NewByteArray(8)
 	iba.pushSuccinctGraftBytes(10, 143)
-	ba.Insert(int(tokenLength), iba)
+	err = ba.Insert(int(tokenLength), iba)
+	if err != nil {
+		t.Errorf("error: %s", err)
+	}
 
 	firstLength, err := ba.Byte(0)
 	if err != nil {
@@ -440,7 +443,10 @@ func TestInsert(t *testing.T) {
 
 	iba2 := NewByteArray(1)
 	iba2.pushSuccinctGraftBytes(5, 47)
-	ba.Insert(int(firstLength+secondLength+thirdLength), iba2)
+	err = ba.Insert(int(firstLength+secondLength+thirdLength), iba2)
+	if err != nil {
+		t.Errorf("error: %s", err)
+	}
 
 	fourthLength, err := ba.Byte(int(firstLength + secondLength + thirdLength))
 	if err != nil {

--- a/succinct/items.go
+++ b/succinct/items.go
@@ -59,3 +59,27 @@ func scopeLabel(enums *Enums, succinct *ByteArray, itemSubType int, pos int) (st
 	}
 	return strings.Join(scopeBits, "/"), nil
 }
+
+func (ba *ByteArray) pushSuccinctTokenBytes(tokenEnumIndex uint8, charsEnumIndex uint32) {
+	lengthPos := len(ba.bytes)
+	ba.PushByte(0)
+	ba.PushByte(tokenEnumIndex)
+	ba.PushNByte(charsEnumIndex)
+	ba.SetByte(lengthPos, uint8((len(ba.bytes)-lengthPos)|itemString2Int["token"]<<6))
+}
+
+func (ba *ByteArray) pushSuccinctGraftBytes(graftTypeEnumIndex uint8, seqEnumIndex uint32) {
+	lengthPos := len(ba.bytes)
+	ba.PushByte(0)
+	ba.PushByte(graftTypeEnumIndex)
+	ba.PushNByte(seqEnumIndex)
+	ba.SetByte(lengthPos, uint8((len(ba.bytes)-lengthPos)|itemString2Int["graft"]<<6))
+}
+
+func (ba *ByteArray) pushSuccinctScopeBytes(itemTypeByte uint8, scopeTypeByte uint8, scopeBitBytes []uint32) {
+	lengthPos := len(ba.bytes)
+	ba.PushByte(0)
+	ba.PushByte(scopeTypeByte)
+	ba.PushNBytes(scopeBitBytes)
+	ba.SetByte(lengthPos, uint8((len(ba.bytes)-lengthPos)|int(itemTypeByte)<<6))
+}


### PR DESCRIPTION
ref issue #13 

- added functions pushSuccinctTokenBytes, pushSuccinctGraftBytes, and pushSuccinctScopeBytes. these were ported from proskomma-utils and are used in multiple unit tests.
- added Insert method
- added unit test for Insert method
